### PR TITLE
Fix GoodReads date format

### DIFF
--- a/anobii-to-goodreads.py
+++ b/anobii-to-goodreads.py
@@ -102,7 +102,7 @@ for l in reader:
 	def convertdate(d):
 	    dt = datetime.strptime(d, "%b %d, %Y")
 	    # Goodreads takes US formatted dates without century (just as stupid as Anobii really)
-	    return dt.strftime("%m/%d/%y")
+	    return dt.strftime("%y/%m/%d")
 	
 	# Fragile but it works
 	status = l[11]
@@ -111,7 +111,7 @@ for l in reader:
 	    if "on" in status:
 	        readdate = convertdate(status[12:])
 	    else:
-	        readdate = "1/1/12"
+	        readdate = "12/1/1"
 	elif "Not Started" in status:
 	    pass
 	elif "Reading":


### PR DESCRIPTION
New date format used by GoodReads is year/month/day
